### PR TITLE
fix: polyfill globalThis.crypto for Netlify build

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build",
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "node -r ./polyfills/crypto.js ./node_modules/.bin/react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/polyfills/crypto.js
+++ b/polyfills/crypto.js
@@ -1,0 +1,6 @@
+// Polyfill globalThis.crypto for Node environments that don't expose Web Crypto globally.
+// Required by serialize-javascript >= 7.x used during the react-scripts build.
+const { webcrypto } = require('crypto');
+if (!globalThis.crypto) {
+  globalThis.crypto = webcrypto;
+}


### PR DESCRIPTION
serialize-javascript ^7.x calls crypto.getRandomValues at module load time, but Netlify's Node 18 environment doesn't expose globalThis.crypto despite the version bump. Pre-load a small polyfill via node -r that maps globalThis.crypto to Node's built-in webcrypto before react-scripts starts bundling.