### PR TITLE
fix: use NODE_OPTIONS to propagate crypto polyfill to webpack workers

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build",
     "start": "react-scripts start",
-    "build": "node -r ./polyfills/crypto.js ./node_modules/.bin/react-scripts build",
+    "build": "NODE_OPTIONS='--require=./polyfills/crypto.js' react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/polyfills/crypto.js
+++ b/polyfills/crypto.js
@@ -1,6 +1,20 @@
-// Polyfill globalThis.crypto for Node environments that don't expose Web Crypto globally.
+// Ensure there's a global crypto with getRandomValues for packages that expect browser crypto.
 // Required by serialize-javascript >= 7.x used during the react-scripts build.
-const { webcrypto } = require('crypto');
+const nodeCrypto = require('crypto');
+
 if (!globalThis.crypto) {
-  globalThis.crypto = webcrypto;
+  if (nodeCrypto.webcrypto) {
+    // Node >= 15 exposes webcrypto as crypto.webcrypto
+    globalThis.crypto = nodeCrypto.webcrypto;
+  } else {
+    // Fallback for older Node: implement getRandomValues using randomFillSync
+    globalThis.crypto = {
+      getRandomValues(arr) {
+        if (!(arr instanceof Uint8Array)) {
+          throw new TypeError('Expected Uint8Array');
+        }
+        return nodeCrypto.randomFillSync(arr);
+      },
+    };
+  }
 }


### PR DESCRIPTION
node -r only applies to the spawning process; webpack child worker processes don't inherit it, so serialize-javascript still failed with "crypto is not defined" in those workers.

NODE_OPTIONS is inherited by all child processes, ensuring globalThis.crypto is polyfilled everywhere serialize-javascript loads during the build.

Also hardened the polyfill with a randomFillSync fallback for older Node.